### PR TITLE
feat(tools)!: Anthropic ToolDialect adapter + bare-noun port refinement (igniteTools PR2)

### DIFF
--- a/.changeset/ignitetools-anthropic-dialect.md
+++ b/.changeset/ignitetools-anthropic-dialect.md
@@ -1,0 +1,12 @@
+---
+"@ignite-element/core": minor
+"@ignite-element/adapters": minor
+"@ignite-element/renderer": minor
+"ignite-element": minor
+---
+
+Add the Anthropic `ToolDialect` adapter — the first provider dialect for igniteTools — on a new `ignite-element/tools/anthropic` entrypoint, and refine the `ToolDialect` port to its final shape.
+
+- **Added — `ignite-element/tools/anthropic`:** a pure, SDK-free `anthropic` dialect (no `@anthropic-ai/sdk` runtime dependency) that translates the neutral manifest to/from the Anthropic Messages tool-use wire format — `tools()` emits `{ name, description?, input_schema }` defs, `toolCalls()` extracts `tool_use` blocks, and `toolResult()` renders `tool_result` blocks (`is_error: true` on a failed call). The consumer brings the SDK and runs the model loop.
+- **Added — shared scalar round-trip (`tools/scalar.ts`):** `toProviderInputSchema`/`fromProviderInput` object-wrap a single-arg command's scalar input under a `value` key for the model and unwrap the returned `{ value }` on the way back — gated on the manifest schema, so an object command with its own `value` field is never unwrapped (collision-free). The neutral manifest stays scalar-honest; wrapping lives only at the provider boundary. PR3 (OpenAI/Ollama) reuses these verbatim.
+- **Breaking (pre-stable beta igniteTools surface) — `ToolDialect` port + `igniteTools` result renamed to bare ecosystem nouns:** `toToolDefs` → `tools`, `parseToolCalls` → `toolCalls` (now `toolCalls(response, manifest)`, the manifest threaded in for scalar unwrap), `toToolResult` → `toolResult`; the consumer execution verb `invoke` → `run`. The bound first argument/type is now `runtime` / `IgniteToolsRuntime` (was `component` / `IgniteToolsComponent`) — it is the agent runtime, not a UI element. `ToolObservation` is unchanged: `run`/`execute` remain act-plus-acknowledgement observations (state at command-acknowledgement; ongoing/remote effects are observed via the view/event stream).

--- a/docs/ignite-tools.md
+++ b/docs/ignite-tools.md
@@ -1,9 +1,13 @@
-# Design: `igniteTools(component)` — hexagonal getSchema → LLM tool-use bridge
+# Design: `igniteTools(runtime)` — hexagonal getSchema → LLM tool-use bridge
 
 ## Status
 
-Proposed (design ✓). **Additive**, non-breaking — `3.x` minor. The agent analog of
-`ignite-element/react`. Agent-runtime thread in `docs/v3-stable-roadmap.md`.
+Implementing. **PR1 shipped** the SDK-neutral core + `ToolDialect` port + the
+`ignite-element/tools` entrypoint (beta.8). **PR2** adds the first provider
+dialect (`ignite-element/tools/anthropic`) and refines the port to its final
+bare-noun shape — breaking to the pre-stable beta igniteTools surface, settled
+before stable. The agent analog of `ignite-element/react`. Agent-runtime thread
+in `docs/v3-stable-roadmap.md`.
 
 ## Context
 
@@ -32,10 +36,10 @@ web UI.
         ▲                  │     → Result<Route, ToolError>│              (actor)
         │                  │                               │               │
    ToolDialect PORT ◄──────┤   ── PORT: ToolDialect ──     │          ┌─ remote actors
-   toToolDefs(manifest)    │   parseToolCalls(resp)        │          │  (location-transparent
-   toToolResult(result)    │   toToolResult(neutralResult) │          └─  via actor-web)
+   tools(manifest)         │   toolCalls(resp, manifest)   │          │  (location-transparent
+   toolResult(result)      │   toolResult(neutralResult)   │          └─  via actor-web)
                            │   IMPERATIVE SHELL            │
-                           │   invoke() → execute() I/O    │
+                           │   run() → execute() I/O       │
                            └──────────────────────────────┘
 ```
 
@@ -55,11 +59,41 @@ provider's tool-calling wire format:
 
 ```ts
 interface ToolDialect<Tools, Response, ResultBlock> {
-  toToolDefs(manifest: NeutralManifest): Tools;          // neutral → provider tool defs
-  parseToolCalls(response: Response): NeutralToolCall[]; // provider response → neutral calls
-  toToolResult(result: NeutralToolResult): ResultBlock;  // neutral result → provider tool_result
+  // neutral manifest → provider tool defs
+  tools(manifest: NeutralManifest): Tools;
+  // provider response → neutral calls (manifest enables scalar unwrap)
+  toolCalls(response: Response, manifest: NeutralManifest): NeutralToolCall[];
+  // neutral result → provider tool_result block
+  toolResult(result: NeutralToolResult): ResultBlock;
 }
 ```
+
+Method names are **bare ecosystem nouns** (`tools` / `toolCalls` / `toolResult`) —
+the typed direction makes encode/decode verbs redundant, and these are the lingua
+franca across Anthropic, OpenAI, the Vercel AI SDK, and LangChain (zero new
+vocabulary). `toolCalls` also receives the `manifest` so it can undo the scalar
+object-wrap — see **Scalar round-trip** below.
+
+### Scalar round-trip (Option D)
+
+Every tool-calling provider requires **object-shaped** tool inputs and returns
+object args, but the neutral manifest is **scalar-honest**: a single-arg command
+(`setLimit(n: number)`) carries a scalar `inputSchema` (`{ type: "number" }`),
+because that is the command's true contract (`getSchema()` must not lie). So the
+wrap/unwrap lives only at the provider boundary, in shared pure helpers
+(`tools/scalar.ts`):
+
+- `toProviderInputSchema(schema)` — wraps a scalar under a clean `value` key
+  (`{ type: "object", properties: { value: schema }, required: ["value"] }`);
+  object/no-arg schemas pass through unchanged. Adapters call it in `tools()`.
+- `fromProviderInput(input, schema)` — unwraps the model's `{ value: x }` back to
+  `x`, **gated on the manifest schema being scalar** (collision-free: an object
+  command that legitimately has its own `value` field is never unwrapped).
+  Adapters call it in `toolCalls()`, which is why the port hands `toolCalls` the
+  manifest.
+
+The constraint is universal across providers, so it is fixed once in the port +
+two helpers; the OpenAI/Ollama dialect reuses them verbatim.
 
 ### Adapters (implement the port — separate entrypoints, SDK-free translators)
 
@@ -78,31 +112,58 @@ interface ToolDialect<Tools, Response, ResultBlock> {
 
 ### Imperative shell
 
-- `invoke(toolCall): Promise<Result<{ snapshot, events }, ToolError>>` — the single
-  side-effect: `component.execute(name, payload)` (which may reach a remote actor). Returns
+- `run(toolCall): Promise<Result<{ snapshot, events }, ToolError>>` — the single
+  side-effect: `runtime.execute(name, payload)` (which may reach a remote actor). Returns
   a `Result` so a failed command is data the agent reacts to, not an exception across the
   seam. The LLM API call itself stays in the **consumer's** loop — `igniteTools` provides
-  the (provider-shaped) `tools` + `invoke`; the consumer runs the model.
+  the (provider-shaped) `tools` + `run`; the consumer runs the model.
 
-### API shape (proposal, refine in PR 1)
+### Observation contract — act + acknowledgement
+
+`run` (and the underlying `execute`) is **act + ACK observation**: the returned
+`ToolObservation` is the snapshot **at command-acknowledgement** plus the events
+emitted up to that point — not "after the effect settles". The actor model has no
+bounded "done" for a long-running effect (a deploy spans minutes and many states),
+and a settle-wait would misattribute unrelated concurrent read-model updates. So
+for async/remote adapters the observation reflects **state at acknowledgement**;
+ongoing effects are observed via the **view/event stream** (`on()` / `watchView()`)
+— the agent loop is act → observe → act, with `canExecute` re-gating the tool list
+as state and transport change. A first-class `observe()` channel on `igniteTools`
+(so act and observe come from one place) is a separate neutral-core task, sequenced
+with the dogfood; a bounded `settle` opt-in on `execute()` is deferred (YAGNI until
+the dogfood shows short-command latency hurts). `ToolObservation` is unchanged.
+
+### API shape
 
 ```ts
 import { igniteTools } from "ignite-element/tools";
 import { anthropic } from "ignite-element/tools/anthropic";
 
-const { tools, invoke } = igniteTools(release, anthropic); // Anthropic-shaped, gated tools
-// neutral core is usable directly too:
-const { manifest, resolveCall, invoke } = igniteTools(release); // no dialect → neutral
+const { tools, toolCalls, run, toolResult } = igniteTools(runtime, anthropic);
+
+// the consumer brings the SDK and runs the model loop:
+const res = await client.messages.create({ model, messages, tools });
+for (const call of toolCalls(res)) {
+  const result = await run(call); // act + ACK observation
+  blocks.push(toolResult({ id: call.id, name: call.name, result }));
+}
+
+// the neutral core is usable directly too:
+const { manifest, resolveCall, run } = igniteTools(runtime); // no dialect → neutral
 ```
+
+`toolCalls(res)` stays single-arg for the consumer — `igniteTools` closes over the
+manifest internally and hands it to the dialect, so scalar unwrapping is invisible
+here.
 
 ## How the design embodies the principles
 
 | Principle | Where it lives |
 | --- | --- |
 | **Hexagonal (ports/adapters)** | `ToolDialect` port; `anthropic`/`openai` adapters; core never imports a provider |
-| **Functional core / imperative shell** | core = `buildManifest`/`resolveCall` (pure); shell = `invoke` (`execute` I/O) |
+| **Functional core / imperative shell** | core = `buildManifest`/`resolveCall` (pure); shell = `run` (`execute` I/O) |
 | **DDD boundaries** | domain = manifest/routing; adapters translate + **return facts (no throw)**; shell coordinates |
-| **Errors as values** | `resolveCall`/`invoke` → `Result<…, ToolError>`; the LLM gets the error back as a `tool_result` |
+| **Errors as values** | `resolveCall`/`run` → `Result<…, ToolError>`; the LLM gets the error back as a `tool_result` |
 | **Actor model + topology** | agent-actor → `[igniteTools seam]` → component-actor → remote actors; a tool-call *is* a message; location-transparent via actor-web |
 | **Projections** | the agent grounds on the **view** (`getView()` / `getSchema().view`), the derived read-model — distinct from the raw snapshot |
 | **TDD** | pure core + each dialect = unit-tested with **zero LLM calls** (golden neutral↔provider fixtures); red→green per piece |
@@ -110,22 +171,25 @@ const { manifest, resolveCall, invoke } = igniteTools(release); // no dialect �
 
 ## `ToolError` (errors as values)
 
-A tagged union returned (never thrown) by `resolveCall`/`invoke`:
+A tagged union returned (never thrown) by `resolveCall`/`run`:
 `UnknownCommand` · `InvalidInput` (fails the command's `inputSchema`) · `Unavailable`
 (`canExecute` false) · `ExecuteFailed` (the command rejected). The consumer maps an `err`
 to the provider's `tool_result` (`is_error: true`) so the model can recover.
 
 ## Sequencing — three PRs (each: branch off `beta` → TDD/DDD + manual validation → `coderabbit review` → PR `--base beta` → CI + CodeRabbit → approve+merge on green → `fas done`; changeset per PR)
 
-1. **PR 1 — core + `ToolDialect` port + a fake dialect.** TDD. No provider SDK. Proves
-   the neutral core (`buildManifest`/`resolveCall`/`invoke` with `Result`) end-to-end
-   against a fake component + fake dialect. Establishes the `ignite-element/tools`
-   entrypoint + the `ToolDialect` interface.
+1. **PR 1 — core + `ToolDialect` port + a fake dialect.** ✓ shipped (beta.8). TDD,
+   no provider SDK. Proves the neutral core (`buildManifest`/`resolveCall`/`run`
+   with `Result`) end-to-end against a fake runtime + fake dialect. Established the
+   `ignite-element/tools` entrypoint + the `ToolDialect` interface.
 2. **PR 2 — `anthropic` adapter** (`ignite-element/tools/anthropic`). Golden
-   neutral↔Anthropic fixtures (TDD). Manual validation: a headless Anthropic loop.
+   neutral↔Anthropic fixtures (TDD); also lands the port's final bare-noun shape +
+   the Option D scalar helpers (`tools/scalar.ts`). Manual validation: a headless
+   Anthropic loop.
 3. **PR 3 — `openai` adapter** (`ignite-element/tools/openai`; covers Codex + Ollama via
-   OpenAI-compat). Golden fixtures (TDD). Manual validation: headless OpenAI **and** a
-   local Ollama (OpenAI-compat) loop — proves the port generalizes cloud→local.
+   OpenAI-compat). Golden fixtures (TDD); reuses the scalar helpers + the refined port.
+   Manual validation: headless OpenAI **and** a local Ollama (OpenAI-compat) loop —
+   proves the port generalizes cloud→local.
 
 ## Dependencies
 

--- a/packages/ignite-element/package.json
+++ b/packages/ignite-element/package.json
@@ -33,6 +33,9 @@
 			],
 			"tools": [
 				"dist/types/tools/index.d.ts"
+			],
+			"tools/anthropic": [
+				"dist/types/tools/anthropic/index.d.ts"
 			]
 		}
 	},
@@ -96,6 +99,12 @@
 			"import": "./dist/tools.es.js",
 			"require": "./dist/tools.cjs.js",
 			"default": "./dist/tools.es.js"
+		},
+		"./tools/anthropic": {
+			"types": "./dist/types/tools/anthropic/index.d.ts",
+			"import": "./dist/tools/anthropic.es.js",
+			"require": "./dist/tools/anthropic.cjs.js",
+			"default": "./dist/tools/anthropic.es.js"
 		},
 		"./package.json": "./package.json"
 	},

--- a/packages/ignite-element/scripts/verify-exports.mjs
+++ b/packages/ignite-element/scripts/verify-exports.mjs
@@ -17,6 +17,7 @@ const expectedPublicSubpaths = [
 	"./jsx/jsx-dev-runtime",
 	"./react",
 	"./tools",
+	"./tools/anthropic",
 	"./package.json",
 ];
 
@@ -30,6 +31,7 @@ const expectedTypesVersions = [
 	"jsx/jsx-dev-runtime",
 	"react",
 	"tools",
+	"tools/anthropic",
 ];
 
 const removedStableSubpaths = [
@@ -76,6 +78,7 @@ const requiredExports = [
 			isErr: "function",
 		},
 	],
+	["./tools/anthropic", { anthropic: "object" }],
 ];
 
 const recursiveImportPattern =

--- a/packages/ignite-element/src/tests/tools.anthropic.test.ts
+++ b/packages/ignite-element/src/tests/tools.anthropic.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from "vitest";
+import type { NeutralManifest, NeutralToolResult } from "../tools";
+import { err, ok } from "../tools";
+import type { AnthropicResponse } from "../tools/anthropic";
+import { anthropic } from "../tools/anthropic";
+
+// Golden neutral <-> Anthropic fixtures (zero SDK, zero network). The adapter is
+// a pure format translator: it maps the neutral manifest to Anthropic tool defs,
+// extracts + unwraps `tool_use` blocks, and renders `tool_result` blocks. The
+// SCALAR command exercises the Option D object-wrap/unwrap (a single-arg command
+// is `{ value }`-wrapped for the model and unwrapped on the way back).
+
+const manifest: NeutralManifest = [
+	// scalar-input command: object-wrapped under `value` for the provider
+	{
+		name: "setLimit",
+		description: "Set the limit.",
+		inputSchema: { type: "number", minimum: 3, maximum: 12 },
+		gated: false,
+	},
+	// object-input command: passed through verbatim
+	{
+		name: "addItem",
+		description: "Add an item.",
+		inputSchema: {
+			type: "object",
+			properties: { name: { type: "string" }, qty: { type: "number" } },
+			required: ["name"],
+		},
+		gated: false,
+	},
+	// no-arg command, no description: empty-object schema, `description` omitted
+	{
+		name: "increment",
+		inputSchema: { type: "object", properties: {} },
+		gated: false,
+	},
+];
+
+describe("anthropic.tools (neutral manifest -> Anthropic tool defs)", () => {
+	it("object-wraps a scalar command's input schema under `value`", () => {
+		const [setLimit] = anthropic.tools(manifest);
+		expect(setLimit).toEqual({
+			name: "setLimit",
+			description: "Set the limit.",
+			input_schema: {
+				type: "object",
+				properties: { value: { type: "number", minimum: 3, maximum: 12 } },
+				required: ["value"],
+			},
+		});
+	});
+
+	it("passes an object command's input schema through unchanged", () => {
+		const addItem = anthropic.tools(manifest)[1];
+		expect(addItem).toEqual({
+			name: "addItem",
+			description: "Add an item.",
+			input_schema: {
+				type: "object",
+				properties: { name: { type: "string" }, qty: { type: "number" } },
+				required: ["name"],
+			},
+		});
+	});
+
+	it("emits an empty-object schema for a no-arg command and omits an absent description", () => {
+		const increment = anthropic.tools(manifest)[2];
+		expect(increment).toEqual({
+			name: "increment",
+			input_schema: { type: "object", properties: {} },
+		});
+		expect("description" in increment).toBe(false);
+	});
+});
+
+describe("anthropic.toolCalls (Anthropic response -> neutral calls)", () => {
+	const response: AnthropicResponse = {
+		content: [
+			// non-tool blocks are ignored
+			{ type: "text", text: "Sure, updating those now." },
+			{
+				type: "tool_use",
+				id: "toolu_1",
+				name: "setLimit",
+				input: { value: 7 },
+			},
+			{
+				type: "tool_use",
+				id: "toolu_2",
+				name: "addItem",
+				input: { name: "apple", qty: 2 },
+			},
+		],
+	};
+
+	it("extracts tool_use blocks, unwrapping a scalar command's { value }", () => {
+		expect(anthropic.toolCalls(response, manifest)).toEqual([
+			{ id: "toolu_1", name: "setLimit", input: 7 },
+			{ id: "toolu_2", name: "addItem", input: { name: "apple", qty: 2 } },
+		]);
+	});
+
+	it("returns no calls when the response carries only non-tool content", () => {
+		const textOnly: AnthropicResponse = {
+			content: [{ type: "text", text: "No tools needed." }],
+		};
+		expect(anthropic.toolCalls(textOnly, manifest)).toEqual([]);
+	});
+
+	it("leaves input untouched for a command not in the manifest", () => {
+		const unknown: AnthropicResponse = {
+			content: [
+				{ type: "tool_use", id: "toolu_x", name: "ghost", input: { value: 1 } },
+			],
+		};
+		expect(anthropic.toolCalls(unknown, manifest)).toEqual([
+			{ id: "toolu_x", name: "ghost", input: { value: 1 } },
+		]);
+	});
+});
+
+describe("anthropic.toolResult (neutral result -> Anthropic tool_result block)", () => {
+	it("renders a successful observation as a non-error block", () => {
+		const result: NeutralToolResult = {
+			id: "toolu_1",
+			name: "setLimit",
+			result: ok({ snapshot: { count: 7 }, events: [] }),
+		};
+		expect(anthropic.toolResult(result)).toEqual({
+			type: "tool_result",
+			tool_use_id: "toolu_1",
+			content: JSON.stringify({ snapshot: { count: 7 }, events: [] }),
+			is_error: false,
+		});
+	});
+
+	it("renders a ToolError as an is_error block carrying the serialized error", () => {
+		const error = {
+			kind: "InvalidInput" as const,
+			name: "setLimit",
+			issues: ["expected a number"],
+		};
+		const result: NeutralToolResult = {
+			id: "toolu_2",
+			name: "setLimit",
+			result: err(error),
+		};
+		expect(anthropic.toolResult(result)).toEqual({
+			type: "tool_result",
+			tool_use_id: "toolu_2",
+			content: JSON.stringify(error),
+			is_error: true,
+		});
+	});
+});

--- a/packages/ignite-element/src/tests/tools.anthropic.test.ts
+++ b/packages/ignite-element/src/tests/tools.anthropic.test.ts
@@ -153,4 +153,12 @@ describe("anthropic.toolResult (neutral result -> Anthropic tool_result block)",
 			is_error: true,
 		});
 	});
+
+	it("throws when the neutral result has no id (Anthropic requires a tool_use_id)", () => {
+		const result: NeutralToolResult = {
+			name: "setLimit",
+			result: ok({ snapshot: { count: 7 }, events: [] }),
+		};
+		expect(() => anthropic.toolResult(result)).toThrow(/tool_use_id/);
+	});
 });

--- a/packages/ignite-element/src/tests/tools.scalar.test.ts
+++ b/packages/ignite-element/src/tests/tools.scalar.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import type { IgniteSchemaObject } from "../types/schema";
+import { fromProviderInput, toProviderInputSchema } from "../tools/scalar";
+
+// Every tool-calling provider (Anthropic / OpenAI / Ollama) requires OBJECT-shaped
+// tool inputs, but the neutral manifest carries SCALAR inputSchema for single-arg
+// commands. These pure helpers object-wrap a scalar for the provider and unwrap the
+// model's `{ value }` back to the bare value — collision-free because the unwrap is
+// gated on the manifest's schema, not a guess.
+
+describe("toProviderInputSchema", () => {
+	it("object-wraps a scalar schema under a `value` property", () => {
+		const scalar: IgniteSchemaObject = { type: "number", minimum: 3, maximum: 12 };
+		expect(toProviderInputSchema(scalar)).toEqual({
+			type: "object",
+			properties: { value: scalar },
+			required: ["value"],
+		});
+	});
+
+	it("wraps a scalar enum the same way", () => {
+		const scalar: IgniteSchemaObject = { type: "string", enum: ["red", "blue"] };
+		expect(toProviderInputSchema(scalar)).toEqual({
+			type: "object",
+			properties: { value: scalar },
+			required: ["value"],
+		});
+	});
+
+	it("passes an object schema through unchanged (same reference)", () => {
+		const obj: IgniteSchemaObject = {
+			type: "object",
+			properties: { name: { type: "string" }, qty: { type: "number" } },
+			required: ["name"],
+		};
+		expect(toProviderInputSchema(obj)).toBe(obj);
+	});
+
+	it("passes the no-arg empty-object schema through unchanged", () => {
+		const empty: IgniteSchemaObject = { type: "object", properties: {} };
+		expect(toProviderInputSchema(empty)).toBe(empty);
+	});
+});
+
+describe("fromProviderInput", () => {
+	it("unwraps { value } to the bare value for a scalar tool schema", () => {
+		expect(fromProviderInput({ value: 7 }, { type: "number" })).toBe(7);
+		expect(fromProviderInput({ value: "red" }, { type: "string" })).toBe("red");
+	});
+
+	it("returns object input unchanged for an object tool schema (collision-safe)", () => {
+		// An object command that legitimately has its own `value` field must NOT be
+		// unwrapped — the manifest schema (type: object) is what prevents it.
+		const input = { value: 7 };
+		const schema: IgniteSchemaObject = {
+			type: "object",
+			properties: { value: { type: "number" } },
+			required: ["value"],
+		};
+		expect(fromProviderInput(input, schema)).toBe(input);
+	});
+
+	it("returns input unchanged when the schema is unknown", () => {
+		expect(fromProviderInput({ value: 7 }, undefined)).toEqual({ value: 7 });
+	});
+
+	it("returns input unchanged for a scalar schema when the input is not a { value } envelope", () => {
+		expect(fromProviderInput(7, { type: "number" })).toBe(7);
+	});
+});

--- a/packages/ignite-element/src/tests/tools.scalar.test.ts
+++ b/packages/ignite-element/src/tests/tools.scalar.test.ts
@@ -10,7 +10,11 @@ import { fromProviderInput, toProviderInputSchema } from "../tools/scalar";
 
 describe("toProviderInputSchema", () => {
 	it("object-wraps a scalar schema under a `value` property", () => {
-		const scalar: IgniteSchemaObject = { type: "number", minimum: 3, maximum: 12 };
+		const scalar: IgniteSchemaObject = {
+			type: "number",
+			minimum: 3,
+			maximum: 12,
+		};
 		expect(toProviderInputSchema(scalar)).toEqual({
 			type: "object",
 			properties: { value: scalar },
@@ -19,7 +23,10 @@ describe("toProviderInputSchema", () => {
 	});
 
 	it("wraps a scalar enum the same way", () => {
-		const scalar: IgniteSchemaObject = { type: "string", enum: ["red", "blue"] };
+		const scalar: IgniteSchemaObject = {
+			type: "string",
+			enum: ["red", "blue"],
+		};
 		expect(toProviderInputSchema(scalar)).toEqual({
 			type: "object",
 			properties: { value: scalar },

--- a/packages/ignite-element/src/tests/tools.test.ts
+++ b/packages/ignite-element/src/tests/tools.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import type { EventDescriptor } from "../RenderArgs";
 import type {
-	IgniteToolsComponent,
+	IgniteToolsRuntime,
 	NeutralManifest,
 	NeutralToolCall,
 	NeutralToolResult,
@@ -52,7 +52,7 @@ const fakeSchema: IgniteAgentSchema<FakeState, FakeView> = {
 	view: { count: 0, label: "zero" },
 };
 
-type FakeComponent = IgniteToolsComponent<
+type FakeComponent = IgniteToolsRuntime<
 	FakeState,
 	Record<string, (...args: never[]) => unknown>,
 	FakeEvents,
@@ -100,11 +100,13 @@ type FakeResultBlock = {
 };
 
 const fakeDialect: ToolDialect<FakeToolDefs, FakeResponse, FakeResultBlock> = {
-	toToolDefs: (manifest: NeutralManifest) =>
+	tools: (manifest: NeutralManifest) =>
 		manifest.map((t) => ({ tool: t.name, schema: t.inputSchema })),
-	parseToolCalls: (response: FakeResponse): NeutralToolCall[] =>
+	// The fake wire format is object-shaped already, so it ignores `manifest`
+	// (no scalar wrapping to undo) — proving the param is optional to consume.
+	toolCalls: (response: FakeResponse): NeutralToolCall[] =>
 		response.calls.map((c) => ({ id: c.id, name: c.name, input: c.input })),
-	toToolResult: (result: NeutralToolResult): FakeResultBlock => ({
+	toolResult: (result: NeutralToolResult): FakeResultBlock => ({
 		tool_use_id: result.id,
 		is_error: isErr(result.result),
 		content: result.result.ok ? result.result.value : result.result.error,
@@ -319,22 +321,22 @@ describe("resolveCall input validation", () => {
 	});
 });
 
-// --- igniteTools factory + invoke shell ---------------------------------------
+// --- igniteTools factory + run shell ------------------------------------------
 
 describe("igniteTools (neutral, no dialect)", () => {
-	it("exposes manifest, resolveCall, and invoke", () => {
+	it("exposes manifest, resolveCall, and run", () => {
 		const component = createFakeComponent();
 		const tools = igniteTools(component);
 		expect(Array.isArray(tools.manifest)).toBe(true);
 		expect(typeof tools.resolveCall).toBe("function");
-		expect(typeof tools.invoke).toBe("function");
+		expect(typeof tools.run).toBe("function");
 		expect("tools" in tools).toBe(false);
 	});
 
-	it("invoke routes a valid call through execute and returns { snapshot, events }", async () => {
+	it("run routes a valid call through execute and returns { snapshot, events }", async () => {
 		const component = createFakeComponent();
-		const { invoke } = igniteTools(component);
-		const result = await invoke({ name: "setLimit", input: 7 });
+		const { run } = igniteTools(component);
+		const result = await run({ name: "setLimit", input: 7 });
 		expect(component.calls).toEqual([{ name: "setLimit", payload: 7 }]);
 		expect(isOk(result)).toBe(true);
 		if (isOk(result)) {
@@ -349,28 +351,28 @@ describe("igniteTools (neutral, no dialect)", () => {
 		}
 	});
 
-	it("invoke does not call execute on an unknown command", async () => {
+	it("run does not call execute on an unknown command", async () => {
 		const component = createFakeComponent();
-		const { invoke } = igniteTools(component);
-		const result = await invoke({ name: "ghost", input: 1 });
+		const { run } = igniteTools(component);
+		const result = await run({ name: "ghost", input: 1 });
 		expect(component.calls).toEqual([]);
 		expect(isErr(result)).toBe(true);
 		if (isErr(result)) expect(result.error.kind).toBe("UnknownCommand");
 	});
 
-	it("invoke does not call execute on invalid input", async () => {
+	it("run does not call execute on invalid input", async () => {
 		const component = createFakeComponent();
-		const { invoke } = igniteTools(component);
-		const result = await invoke({ name: "setLimit", input: "bad" });
+		const { run } = igniteTools(component);
+		const result = await run({ name: "setLimit", input: "bad" });
 		expect(component.calls).toEqual([]);
 		expect(isErr(result)).toBe(true);
 		if (isErr(result)) expect(result.error.kind).toBe("InvalidInput");
 	});
 
-	it("invoke captures an execute rejection as ExecuteFailed (never throws across the seam)", async () => {
+	it("run captures an execute rejection as ExecuteFailed (never throws across the seam)", async () => {
 		const component = createFakeComponent();
-		const { invoke } = igniteTools(component);
-		const result = await invoke({ name: "boom", input: undefined });
+		const { run } = igniteTools(component);
+		const result = await run({ name: "boom", input: undefined });
 		expect(isErr(result)).toBe(true);
 		if (isErr(result)) {
 			expect(result.error.kind).toBe("ExecuteFailed");
@@ -381,19 +383,19 @@ describe("igniteTools (neutral, no dialect)", () => {
 		}
 	});
 
-	it("invoke returns Unavailable when availability flips after the manifest is built", async () => {
+	it("run returns Unavailable when availability flips after the manifest is built", async () => {
 		// Availability is dynamic (snapshot-dependent): the command is offered at
-		// manifest-build time but becomes unavailable before it is invoked.
+		// manifest-build time but becomes unavailable before the call runs.
 		let adminAvailable = true;
 		const component = createFakeComponent({
 			canExecute: (name) => name !== "adminOnly" || adminAvailable,
 		});
-		const { manifest, invoke } = igniteTools(component);
+		const { manifest, run } = igniteTools(component);
 		// Offered at build time.
 		expect(manifest.find((t) => t.name === "adminOnly")).toBeDefined();
 		// Snapshot changes -> command no longer available.
 		adminAvailable = false;
-		const result = await invoke({ name: "adminOnly", input: undefined });
+		const result = await run({ name: "adminOnly", input: undefined });
 		expect(component.calls).toEqual([]);
 		expect(isErr(result)).toBe(true);
 		if (isErr(result)) expect(result.error.kind).toBe("Unavailable");
@@ -409,33 +411,30 @@ describe("igniteTools (neutral, no dialect)", () => {
 });
 
 describe("igniteTools (with a ToolDialect)", () => {
-	it("exposes provider tool defs plus parse/result helpers", () => {
+	it("exposes provider tool defs plus toolCalls/toolResult helpers", () => {
 		const component = createFakeComponent();
 		const tools = igniteTools(component, fakeDialect);
 		expect(tools.tools).toEqual(
 			tools.manifest.map((t) => ({ tool: t.name, schema: t.inputSchema })),
 		);
-		expect(typeof tools.parseToolCalls).toBe("function");
-		expect(typeof tools.toToolResult).toBe("function");
+		expect(typeof tools.toolCalls).toBe("function");
+		expect(typeof tools.toolResult).toBe("function");
 	});
 
-	it("round-trips a provider response: parse -> invoke -> toToolResult", async () => {
+	it("round-trips a provider response: toolCalls -> run -> toolResult", async () => {
 		const component = createFakeComponent();
-		const { parseToolCalls, invoke, toToolResult } = igniteTools(
-			component,
-			fakeDialect,
-		);
+		const { toolCalls, run, toolResult } = igniteTools(component, fakeDialect);
 
 		const response: FakeResponse = {
 			calls: [{ id: "call_1", name: "setLimit", input: 8 }],
 		};
-		const calls = parseToolCalls(response);
+		const calls = toolCalls(response);
 		expect(calls).toEqual([{ id: "call_1", name: "setLimit", input: 8 }]);
 
-		const result = await invoke(calls[0]);
+		const result = await run(calls[0]);
 		expect(isOk(result)).toBe(true);
 
-		const block = toToolResult({
+		const block = toolResult({
 			id: calls[0].id,
 			name: calls[0].name,
 			result,
@@ -445,23 +444,23 @@ describe("igniteTools (with a ToolDialect)", () => {
 
 	it("maps a failed command into an error tool-result block", async () => {
 		const component = createFakeComponent();
-		const { invoke, toToolResult } = igniteTools(component, fakeDialect);
+		const { run, toolResult } = igniteTools(component, fakeDialect);
 		const call: NeutralToolCall = {
 			id: "call_2",
 			name: "boom",
 			input: undefined,
 		};
-		const result = await invoke(call);
-		const block = toToolResult({ id: call.id, name: call.name, result });
+		const result = await run(call);
+		const block = toolResult({ id: call.id, name: call.name, result });
 		expect(block).toMatchObject({ tool_use_id: "call_2", is_error: true });
 	});
 
 	it("never throws across the seam even when execute rejects", async () => {
 		const component = createFakeComponent();
 		const spy = vi.spyOn(component, "execute");
-		const { invoke } = igniteTools(component, fakeDialect);
+		const { run } = igniteTools(component, fakeDialect);
 		await expect(
-			invoke({ name: "boom", input: undefined }),
+			run({ name: "boom", input: undefined }),
 		).resolves.toMatchObject({ ok: false });
 		expect(spy).toHaveBeenCalledTimes(1);
 	});

--- a/packages/ignite-element/src/tests/types/tools.types.test.ts
+++ b/packages/ignite-element/src/tests/types/tools.types.test.ts
@@ -32,22 +32,22 @@ describe("igniteTools types", () => {
 
 	type ComponentSnapshot = ReturnType<typeof component.getSnapshot>;
 
-	it("exposes a NeutralManifest and an errors-as-values invoke", () => {
-		const { manifest, resolveCall, invoke } = igniteTools(component);
+	it("exposes a NeutralManifest and an errors-as-values run", () => {
+		const { manifest, resolveCall, run } = igniteTools(component);
 
 		expectTypeOf(manifest).toEqualTypeOf<NeutralManifest>();
 		expectTypeOf(resolveCall).toBeFunction();
-		expectTypeOf(invoke).toBeFunction();
+		expectTypeOf(run).toBeFunction();
 	});
 
-	it("types the invoke observation from the component's snapshot + events", () => {
-		const { invoke } = igniteTools(component);
+	it("types the run observation from the component's snapshot + events", () => {
+		const { run } = igniteTools(component);
 
 		// Wrapped uncalled: the body is typechecked but never executed (these
 		// `.types.test.ts` files also run under vitest). The success branch carries
 		// the component's snapshot + typed events; the failure branch is ToolError.
 		const probe = async () => {
-			const result = await invoke({ name: "toggle", input: undefined });
+			const result = await run({ name: "toggle", input: undefined });
 
 			if (result.ok) {
 				expectTypeOf(result.value.snapshot).toEqualTypeOf<ComponentSnapshot>();
@@ -67,18 +67,16 @@ describe("igniteTools types", () => {
 		type Block = { id?: string };
 
 		const dialect: ToolDialect<Defs, Resp, Block> = {
-			toToolDefs: (manifest) => manifest.map((t) => ({ tool: t.name })),
-			parseToolCalls: (response) => response.calls,
-			toToolResult: (result) => ({ id: result.id }),
+			tools: (manifest) => manifest.map((t) => ({ tool: t.name })),
+			toolCalls: (response) => response.calls,
+			toolResult: (result) => ({ id: result.id }),
 		};
 
 		const tools = igniteTools(component, dialect);
 
 		expectTypeOf(tools.tools).toEqualTypeOf<Defs>();
-		expectTypeOf(tools.parseToolCalls).parameter(0).toEqualTypeOf<Resp>();
-		expectTypeOf(tools.parseToolCalls).returns.toEqualTypeOf<
-			NeutralToolCall[]
-		>();
-		expectTypeOf(tools.toToolResult).returns.toEqualTypeOf<Block>();
+		expectTypeOf(tools.toolCalls).parameter(0).toEqualTypeOf<Resp>();
+		expectTypeOf(tools.toolCalls).returns.toEqualTypeOf<NeutralToolCall[]>();
+		expectTypeOf(tools.toolResult).returns.toEqualTypeOf<Block>();
 	});
 });

--- a/packages/ignite-element/src/tools/anthropic/index.ts
+++ b/packages/ignite-element/src/tools/anthropic/index.ts
@@ -1,0 +1,109 @@
+import type { IgniteSchemaObject } from "../../types/schema";
+import { isOk } from "../result";
+import { fromProviderInput, toProviderInputSchema } from "../scalar";
+import type {
+	NeutralManifest,
+	NeutralToolCall,
+	NeutralToolResult,
+	ToolDialect,
+} from "../types";
+
+/**
+ * Anthropic Messages tool-use dialect — a pure, SDK-free `ToolDialect`. It
+ * translates the neutral manifest to/from the documented Anthropic Messages
+ * wire shapes; the consumer brings `@anthropic-ai/sdk` (or `fetch`) and runs the
+ * model loop. The structural wire types below are the minimal subset igniteTools
+ * touches, not a vendored copy of the SDK's types.
+ *
+ * @see https://docs.anthropic.com/en/api/messages — tool use
+ */
+
+/**
+ * An Anthropic tool definition. `input_schema` is always an object schema; a
+ * scalar command is object-wrapped by {@link toProviderInputSchema} (Option D).
+ */
+export type AnthropicTool = {
+	name: string;
+	description?: string;
+	input_schema: IgniteSchemaObject;
+};
+
+/** An Anthropic `tool_use` content block (the model's request to call a tool). */
+export type AnthropicToolUseBlock = {
+	type: "tool_use";
+	id: string;
+	name: string;
+	input: unknown;
+};
+
+/** One block of an Anthropic Messages response `content` array. */
+export type AnthropicContentBlock =
+	| AnthropicToolUseBlock
+	| { type: string; [key: string]: unknown };
+
+/** The slice of an Anthropic Messages response the dialect reads tool calls from. */
+export type AnthropicResponse = {
+	content: AnthropicContentBlock[];
+};
+
+/**
+ * An Anthropic `tool_result` content block, returned to the model on the next
+ * turn. `content` is the JSON-serialized observation (or error); `is_error`
+ * flags a failed call so the model can recover.
+ */
+export type AnthropicToolResultBlock = {
+	type: "tool_result";
+	tool_use_id: string | undefined;
+	content: string;
+	is_error: boolean;
+};
+
+/**
+ * The Anthropic tool-use dialect. Stateless and provider-SDK-free, so it is a
+ * shared singleton.
+ */
+export const anthropic: ToolDialect<
+	AnthropicTool[],
+	AnthropicResponse,
+	AnthropicToolResultBlock
+> = {
+	tools(manifest: NeutralManifest): AnthropicTool[] {
+		return manifest.map((tool) => {
+			const definition: AnthropicTool = {
+				name: tool.name,
+				input_schema: toProviderInputSchema(tool.inputSchema),
+			};
+			if (tool.description !== undefined) {
+				definition.description = tool.description;
+			}
+			return definition;
+		});
+	},
+
+	toolCalls(
+		response: AnthropicResponse,
+		manifest: NeutralManifest,
+	): NeutralToolCall[] {
+		return response.content
+			.filter(
+				(block): block is AnthropicToolUseBlock => block.type === "tool_use",
+			)
+			.map((block) => ({
+				id: block.id,
+				name: block.name,
+				input: fromProviderInput(
+					block.input,
+					manifest.find((tool) => tool.name === block.name)?.inputSchema,
+				),
+			}));
+	},
+
+	toolResult({ id, result }: NeutralToolResult): AnthropicToolResultBlock {
+		return {
+			type: "tool_result",
+			tool_use_id: id,
+			content: JSON.stringify(isOk(result) ? result.value : result.error),
+			is_error: !isOk(result),
+		};
+	},
+};

--- a/packages/ignite-element/src/tools/anthropic/index.ts
+++ b/packages/ignite-element/src/tools/anthropic/index.ts
@@ -48,12 +48,14 @@ export type AnthropicResponse = {
 
 /**
  * An Anthropic `tool_result` content block, returned to the model on the next
- * turn. `content` is the JSON-serialized observation (or error); `is_error`
- * flags a failed call so the model can recover.
+ * turn. `tool_use_id` correlates it with the originating `tool_use` block (always
+ * present in an Anthropic response, so always required here); `content` is the
+ * JSON-serialized observation (or error); `is_error` flags a failed call so the
+ * model can recover.
  */
 export type AnthropicToolResultBlock = {
 	type: "tool_result";
-	tool_use_id: string | undefined;
+	tool_use_id: string;
 	content: string;
 	is_error: boolean;
 };
@@ -99,6 +101,15 @@ export const anthropic: ToolDialect<
 	},
 
 	toolResult({ id, result }: NeutralToolResult): AnthropicToolResultBlock {
+		// Anthropic rejects a tool_result without a tool_use_id. The neutral id is
+		// optional (provider-agnostic), but for Anthropic it always originates from
+		// a tool_use block via toolCalls() — a missing id is a pairing bug, not an
+		// expected error, so fail fast rather than emit an invalid block.
+		if (id === undefined) {
+			throw new Error(
+				"anthropic.toolResult requires a tool_use_id; pass the id from the originating tool_use block (call.id from toolCalls()).",
+			);
+		}
 		return {
 			type: "tool_result",
 			tool_use_id: id,

--- a/packages/ignite-element/src/tools/igniteTools.ts
+++ b/packages/ignite-element/src/tools/igniteTools.ts
@@ -8,7 +8,7 @@ import { buildManifest, resolveCall } from "./core";
 import { err, ok, type Result } from "./result";
 import type {
 	AvailabilityPredicate,
-	IgniteToolsComponent,
+	IgniteToolsRuntime,
 	NeutralManifest,
 	NeutralToolCall,
 	NeutralToolResult,
@@ -22,7 +22,7 @@ import type {
 export type IgniteToolsNeutral<State, Events extends EventMap> = {
 	manifest: NeutralManifest;
 	resolveCall(name: string, input: unknown): Result<Route, ToolError>;
-	invoke(
+	run(
 		call: NeutralToolCall,
 	): Promise<Result<ToolObservation<State, Events>, ToolError>>;
 };
@@ -36,8 +36,8 @@ export type IgniteToolsWithDialect<
 	ResultBlock,
 > = IgniteToolsNeutral<State, Events> & {
 	tools: Tools;
-	parseToolCalls(response: Response): NeutralToolCall[];
-	toToolResult(result: NeutralToolResult<State, Events>): ResultBlock;
+	toolCalls(response: Response): NeutralToolCall[];
+	toolResult(result: NeutralToolResult<State, Events>): ResultBlock;
 };
 
 export function igniteTools<
@@ -47,7 +47,7 @@ export function igniteTools<
 	SchemaState,
 	View extends Record<string, unknown>,
 >(
-	component: IgniteToolsComponent<State, Commands, Events, SchemaState, View>,
+	runtime: IgniteToolsRuntime<State, Commands, Events, SchemaState, View>,
 ): IgniteToolsNeutral<State, Events>;
 export function igniteTools<
 	State,
@@ -59,30 +59,30 @@ export function igniteTools<
 	Response,
 	ResultBlock,
 >(
-	component: IgniteToolsComponent<State, Commands, Events, SchemaState, View>,
+	runtime: IgniteToolsRuntime<State, Commands, Events, SchemaState, View>,
 	dialect: ToolDialect<Tools, Response, ResultBlock>,
 ): IgniteToolsWithDialect<State, Events, Tools, Response, ResultBlock>;
 /**
  * Bridge the agent-runtime contract to LLM tool-use. The pure core builds a
  * neutral manifest from `getSchema()` and routes validated calls; the shell
- * (`invoke`) performs the single `execute` side effect. With a `ToolDialect`,
+ * (`run`) performs the single `execute` side effect. With a `ToolDialect`,
  * the result also carries provider-shaped `tools` and the parse/result
  * translators — the consumer brings the SDK and runs the model loop.
  */
 export function igniteTools(
-	component: IgniteToolsComponent,
+	runtime: IgniteToolsRuntime,
 	dialect?: ToolDialect,
 ) {
 	const canExecute: AvailabilityPredicate | undefined =
-		typeof component.canExecute === "function"
-			? component.canExecute.bind(component)
+		typeof runtime.canExecute === "function"
+			? runtime.canExecute.bind(runtime)
 			: undefined;
 
-	const manifest = buildManifest(component.getSchema(), canExecute);
+	const manifest = buildManifest(runtime.getSchema(), canExecute);
 
 	// The model supplies dynamic command names, so treat `execute` as the loose
 	// runtime contract at this boundary.
-	const execute = component.execute as unknown as (
+	const execute = runtime.execute as unknown as (
 		name: string,
 		payload?: unknown,
 	) => Promise<IgniteAgentExecutionResult<unknown, EmptyEventMap>>;
@@ -92,7 +92,7 @@ export function igniteTools(
 		input: unknown,
 	): Result<Route, ToolError> => resolveCall(manifest, name, input, canExecute);
 
-	const invoke = async (
+	const run = async (
 		call: NeutralToolCall,
 	): Promise<Result<ToolObservation<unknown, EmptyEventMap>, ToolError>> => {
 		const routed = boundResolveCall(call.name, call.input);
@@ -116,7 +116,7 @@ export function igniteTools(
 		}
 	};
 
-	const neutral = { manifest, resolveCall: boundResolveCall, invoke };
+	const neutral = { manifest, resolveCall: boundResolveCall, run };
 
 	if (!dialect) {
 		return neutral;
@@ -124,8 +124,8 @@ export function igniteTools(
 
 	return {
 		...neutral,
-		tools: dialect.toToolDefs(manifest),
-		parseToolCalls: (response: unknown) => dialect.parseToolCalls(response),
-		toToolResult: (result: NeutralToolResult) => dialect.toToolResult(result),
+		tools: dialect.tools(manifest),
+		toolCalls: (response: unknown) => dialect.toolCalls(response, manifest),
+		toolResult: (result: NeutralToolResult) => dialect.toolResult(result),
 	};
 }

--- a/packages/ignite-element/src/tools/index.ts
+++ b/packages/ignite-element/src/tools/index.ts
@@ -8,7 +8,7 @@ export type { Err, Ok, Result } from "./result";
 export { err, isErr, isOk, ok } from "./result";
 export type {
 	AvailabilityPredicate,
-	IgniteToolsComponent,
+	IgniteToolsRuntime,
 	NeutralManifest,
 	NeutralTool,
 	NeutralToolCall,

--- a/packages/ignite-element/src/tools/scalar.ts
+++ b/packages/ignite-element/src/tools/scalar.ts
@@ -1,0 +1,62 @@
+import type { IgniteSchemaObject } from "../types/schema";
+
+/**
+ * Shared, provider-agnostic scalar/object bridging for `ToolDialect` adapters.
+ *
+ * Every tool-calling provider (Anthropic / OpenAI+Codex / Ollama) requires
+ * tool inputs to be JSON-Schema **objects** and returns the model's arguments as
+ * an object. The neutral manifest, however, carries the command's *true* schema —
+ * which is **scalar** for a single-arg command (`createShipment(id: string)` →
+ * `{ type: "string" }`). So an adapter object-wraps a scalar for the model and
+ * unwraps the returned `{ value: … }` back to the bare value before it reaches
+ * `resolveCall`. Keeping this in one pure place means anthropic/openai/ollama all
+ * share it, and the manifest stays scalar-honest (the wrapping lives only at the
+ * provider boundary).
+ */
+
+/** The property a scalar command's single value is wrapped under for the model. */
+const SCALAR_KEY = "value";
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Render a command's neutral input schema as a provider-acceptable **object**
+ * schema. Object/no-arg schemas pass through unchanged (same reference); a scalar
+ * schema is wrapped under `value`.
+ */
+export function toProviderInputSchema(
+	schema: IgniteSchemaObject,
+): IgniteSchemaObject {
+	if (schema.type === "object") {
+		return schema;
+	}
+	return {
+		type: "object",
+		properties: { [SCALAR_KEY]: schema },
+		required: [SCALAR_KEY],
+	};
+}
+
+/**
+ * Reverse {@link toProviderInputSchema}: a scalar command's model input arrives as
+ * `{ value: x }`; unwrap it to `x` so `resolveCall` validates against the true
+ * scalar schema. Unwrapping is gated on the manifest schema being scalar (not a
+ * guess on the shape), so an object command that legitimately carries a `value`
+ * field is never unwrapped.
+ */
+export function fromProviderInput(
+	input: unknown,
+	schema: IgniteSchemaObject | undefined,
+): unknown {
+	if (
+		schema !== undefined &&
+		schema.type !== "object" &&
+		isPlainObject(input) &&
+		SCALAR_KEY in input
+	) {
+		return input[SCALAR_KEY];
+	}
+	return input;
+}

--- a/packages/ignite-element/src/tools/types.ts
+++ b/packages/ignite-element/src/tools/types.ts
@@ -33,7 +33,7 @@ export type NeutralTool = {
 export type NeutralManifest = NeutralTool[];
 
 /**
- * A provider-agnostic tool call, produced by a dialect's `parseToolCalls`. The
+ * A provider-agnostic tool call, produced by a dialect's `toolCalls`. The
  * `input` is untyped on purpose: it originates from the model and is validated
  * by `resolveCall` before it ever reaches a command.
  */
@@ -56,7 +56,7 @@ export type ToolObservation<
 };
 
 /**
- * Errors as values. Returned (never thrown) by `resolveCall`/`invoke` so the
+ * Errors as values. Returned (never thrown) by `resolveCall`/`run` so the
  * consumer can map an error into the provider's `tool_result` (`is_error: true`)
  * and let the model recover.
  */
@@ -76,8 +76,8 @@ export type Route<Name extends string = string, Payload = unknown> = {
 };
 
 /**
- * The input to a dialect's `toToolResult`: a tool call's correlation id/name
- * paired with the `invoke` outcome.
+ * The input to a dialect's `toolResult`: a tool call's correlation id/name
+ * paired with the `run` outcome.
  */
 export type NeutralToolResult<
 	Snapshot = unknown,
@@ -92,15 +92,28 @@ export type NeutralToolResult<
  * The provider boundary (the port). A pure format translator between the neutral
  * manifest and one provider's tool-calling wire format. Adapters implementing
  * this carry no provider-SDK runtime dependency.
+ *
+ * Method names are bare ecosystem nouns — the typed direction (manifest in vs.
+ * response in) makes encode/decode verbs redundant, and `tools`/`toolCalls`/
+ * `toolResult` are the lingua franca across Anthropic, OpenAI, the Vercel AI
+ * SDK, and LangChain.
  */
 export interface ToolDialect<
 	Tools = unknown,
 	Response = unknown,
 	ResultBlock = unknown,
 > {
-	toToolDefs(manifest: NeutralManifest): Tools;
-	parseToolCalls(response: Response): NeutralToolCall[];
-	toToolResult(result: NeutralToolResult): ResultBlock;
+	/** Neutral manifest → provider tool definitions. */
+	tools(manifest: NeutralManifest): Tools;
+	/**
+	 * Provider response → neutral tool calls. Receives the `manifest` so the
+	 * adapter can unwrap a scalar command's object-wrapped `{ value }` argument
+	 * back to the bare value (see `tools/scalar.ts`); the unwrap is gated on the
+	 * manifest schema, so it is collision-free.
+	 */
+	toolCalls(response: Response, manifest: NeutralManifest): NeutralToolCall[];
+	/** Neutral result → provider tool-result block (encoded one call at a time). */
+	toolResult(result: NeutralToolResult): ResultBlock;
 }
 
 /** Per-command availability predicate, evaluated against the current snapshot. */
@@ -113,7 +126,7 @@ export type AvailabilityPredicate = (name: string) => boolean;
  * duck-typed: present once it ships on the runtime, it gates the manifest;
  * absent today, all commands are offered.
  */
-export type IgniteToolsComponent<
+export type IgniteToolsRuntime<
 	State = unknown,
 	Commands extends FacadeCommandResult = FacadeCommandResult,
 	Events extends EventMap = EmptyEventMap,

--- a/packages/ignite-element/vite.config.ts
+++ b/packages/ignite-element/vite.config.ts
@@ -32,6 +32,7 @@ export default defineConfig(({ command }) => ({
 			"jsx/jsx-dev-runtime": "src/jsx/jsx-dev-runtime.ts",
 			react: "src/react/index.ts",
 			tools: "src/tools/index.ts",
+			"tools/anthropic": "src/tools/anthropic/index.ts",
 		},
 		external: [
 			"@ignite-element/core",


### PR DESCRIPTION
## Summary

igniteTools **PR2** — the first real provider dialect. Builds on PR1 (#64, the SDK-neutral core + `ToolDialect` port, in beta.8). Adds the **Anthropic** dialect on a new `ignite-element/tools/anthropic` entrypoint, lands the **Option D** scalar round-trip in shared pure helpers, and refines the `ToolDialect` port to its final bare-noun shape.

Design: [`docs/ignite-tools.md`](docs/ignite-tools.md).

## What's included

- **`ignite-element/tools/anthropic`** — a pure, SDK-free `anthropic` `ToolDialect` (no `@anthropic-ai/sdk` runtime dep). Translates the neutral manifest to/from the Anthropic Messages wire format: `tools()` → `{ name, description?, input_schema }`; `toolCalls(response, manifest)` extracts `tool_use` blocks; `toolResult({ id, result })` renders `tool_result` blocks (`is_error` on failure, and requires a `tool_use_id`). The consumer brings the SDK and runs the model loop.
- **Scalar round-trip (Option D)** — shared pure helpers in `tools/scalar.ts` (`toProviderInputSchema` / `fromProviderInput`) object-wrap a single-arg command's scalar input under `value` for the model and unwrap the returned `{ value }`, gated on the manifest schema (collision-free). The neutral manifest stays scalar-honest; wrapping lives only at the provider boundary. PR3 (OpenAI/Ollama) reuses these verbatim.
- **Port renamed to bare ecosystem nouns** — `toToolDefs` → `tools`, `parseToolCalls` → `toolCalls(response, manifest)` (manifest threaded in for the scalar unwrap), `toToolResult` → `toolResult`; consumer execution verb `invoke` → `run`. The bound runtime arg/type is `runtime` / `IgniteToolsRuntime` (was `component` / `IgniteToolsComponent`).
- Golden neutral↔Anthropic fixtures (scalar / object / no-arg shapes), docs update, and a lockstep minor changeset.

## ⚠️ Breaking (pre-stable beta igniteTools surface)

The `ToolDialect` port and `igniteTools` result methods are renamed (above). This touches only the beta.8 igniteTools surface — pre-stable, settled before the stable cut. `ToolObservation` is unchanged: `run`/`execute` remain **act + acknowledgement** observations (state at command-acknowledgement; ongoing/remote effects observed via the view/event stream). A first-class `observe()` channel is a separate task sequenced with the dogfood.

## Verification

- `npm run typecheck` (all packages) + `npm test` (447) green.
- `verify.sh --full` green (format, lint, typecheck, test, architecture drift, behavior boundaries, semantic index).
- `pnpm build` green — the new `./tools/anthropic` entrypoint resolves through `verify-exports`.
- `coderabbit review` (CLI) clean (the real gate — CodeRabbit's app auto-review is disabled on non-default base branches).

## Next

PR3 — `openai` adapter (covers Codex + Ollama via OpenAI-compat), reusing the scalar helpers + the refined port.